### PR TITLE
More aliases, less ruletables

### DIFF
--- a/js/alias.js
+++ b/js/alias.js
@@ -292,6 +292,8 @@ This file is part of LifeViewer
 		s.push("INT Hex");
 		a.push(["Isotropic Non-Totalistic Hex", ""]);
 		a.push(["Hex Life", "B2o3m56/S2-p4oH"]);
+		a.push(["Hex Inverse Fire", "B2-m4-m56/S2m34m56H"]);
+		a.push(["HexLife", "B3o/S234-o6H"]);
 		a.push(["22da", "B2/S2-mH"]);
 		a.push(["Hexrule b2o", "B2o/S2m34H"]);
 
@@ -377,7 +379,7 @@ This file is part of LifeViewer
 		a.push(["Extension", "B2cei3-ijnr4-a6i/S12-cn"]);
 		a.push(["fakePiShipLife", "B3-ck4e5k6i/S2-in35i6c8"]);
 		a.push(["FalseB5", "B35ce/S234jqtyz6k8"]);
-		a.push(["Frespa", "B34ck5/S23aceik4aci"]);
+		a.push(["Farespa", "B34ck5/S23aceik4aci"]);
 		a.push(["FattyLife", "B3-n4nt5qr6i/S23"]);
 		a.push(["FishLife", "B3-ekqr4nt5r6i/S02-c3"]);
 		a.push(["FlashLife", "B2kn3-n4e/S23"]);
@@ -432,6 +434,7 @@ This file is part of LifeViewer
 		a.push(["Knyght", "B2e3/S23-jq"]);
 		a.push(["ktlife", "B3/S2-i34nq"]);
 		a.push(["LambdaLife", "B3-k/S2-i3-k4cen"]);
+		a.push(["LeapLife", "B2n3/S23-q"]);
 		a.push(["Leaplized D&N", "B2n3678/S3-q4678"]);
 		a.push(["LifeWithoutGliders", "B35n/S23"]);
 		a.push(["Linea", "B2-a3-i/S23-a"]);
@@ -561,7 +564,7 @@ This file is part of LifeViewer
 		a.push(["Worms 0", "B01c2n5a/S3a5i"]);
 		a.push(["Writers", "B2-a3-inqr4c6/S23"]);
 		a.push(["WSScentral", "B3-n45qr6i/S2eik3"]);
-		a.push(["X-rule-pre", "B2cei3ci4jnr5ikn/S12aen3c4einqy5er6aei8"]);
+		a.push(["x-rule-pre", "B2cei3ci4jnr5ikn/S12aen3c4einqy5er6aei8"]);
 		a.push(["xtdbee", "B3-k/S23"]);
 		a.push(["xvaLifeg", "B2e3/S23"]);
 		a.push(["Ylife", "B2e3ai4ar/S23-a4a"]);
@@ -642,16 +645,21 @@ This file is part of LifeViewer
 		a.push(["MAP Non-Isotropic", ""]);
 		a.push(["2CellSlug", "MAPBTDe/yAA9/8AAP//AAD//yAA/78AAP//AID//wAA//8AAP//AAD/2wAA//8AgP//AAD//4AA//+AAH//AAD//w"]);
 		a.push(["BLAHTWOCELLGUN", "MAPAMB/vwAA//8AAP//AAD//wAA//8AAP//AAD//wAA//8AAP//AAD//wAA//8AAP//AAD//wAA//8AAP//AAD//w"]);
+		a.push(["cloverleafsim", "MAPAAD//zAwPz8AAP//MDA/PwAA//8AAP//AAD//wAA//8AAD8/AAD//wAAPz8AAP//wMD//wAA///AwP//AAD//D"]);
 		a.push(["FoxLife", "MAPARYXfhZofugWaH7oaIFoxBZofuhogOiAaIFoxIAAgAAWaH7oaIFoxGiA6ICAAIAAaIFoxIAAgACAAIAAAAAAAA"]);
+		a.push(["MaxPeriod_2x2k2", "MAPADC9vyIA/f8AAH//AAD//wCA//+AAP//AID/fwAA//8AAH//AAB//wAA//8AAP//AAD//4AA//8AAP//AAD//D"]);
 		a.push(["MovingStrings", "MAPARH+/wMT//8BEf7/AxP//wER/v8DE///AREAAAMTAAABEf7/AxP//wER/v8DE///AREAAAMTAAABEQAAAxMAAA"]);
 		a.push(["MuzikThing", "MAPACD//wAA3/8AgH//AAD//wCAf/8AAP//AAD//wAA//8AAH//AAD//wAA//8AAP//gAD//wAA//8AAP//AAD//w"]);
 		a.push(["MyEntry", "MAPIAD/7wgA/f8AAP//AAD//wAA//8AAP//AAD/fwAA//8AAP//AAD//wAA//8AAP//AAD//4AA//8AAP//AAD//w"]);
+		a.push(["randomnn", "MAPA1Az8wMAqgAAUADAAAAAAAAAgMAAAIAAgICAwAAAgAAAAAAAiACqAAAAAAAAAAAAAACAAIgAgACAgIAAAACAAA"]);
 		a.push(["OLife", "MAPABD/vgIB//8AAP//AAD//wAA/78AAN3/AJB/vwAAf/8AAP//AABd/wAA//8AAP//AAD//4IA//8AAP//AIB//w"]);
 		a.push(["Rhufo", "MAPARH//wMA//8AAP9/AAD//wAA//8AAP9/AAD//wAA//8AAP//AAB//wAA//8AAP//AAD//wAA//8AAH9/AAB//w"]);
 		a.push(["Rhufo2", "MAPARH//wMA//8AAH9/AAD//wAAX/8AAP9/AAB/7wAA//8AAH//AAB//wAA//8AAP//AAB//wAA/f8AAH8/AAB3/w"]);
 		a.push(["SemiFelineLife", "MAPARYXfhZofugWaH7oaIDogBZofuhogOiAaIDogIAAgAAWaH7oaICatGiA6ICAAIAAaICatIAAgACAAIAAAAAAAA"]);
 		a.push(["Simple_Weird_Ships", "MAPABHs/wMA//8AAP//AAD//wAA/38AAP//AAD//wAA//8AAP//gAD//wAA//8AAP//AAD//wAA//8AAP//AAD//w"]);
 		a.push(["Socrates", "MAPARYXfhZofugWaH7oaIDogBZofuhogOiAaIDogIAAgAAWaH7oaIDogGiA6ICAAIAAaIDogIAAg00IAmSocrateg"]);
+		a.push(["x-rule", "MAPBSB64CCTqARFBImEADAGBSCTgICTSIAAADCFCSTAAAANAMEUBCKEBchCE00YAE3IACSFACCIQQDIIF4UIIAGSA"]);
+		a.push(["water", "MAPABAbrwAA//8AQltdAAD+/8Aa/f8AAP//YgD//wAA//8AAP//QAD//wBA//8AAP/fAgD3+wKA//8AIPZ/AAD//D"]);
 
 		// add weighted aliases
 		s.push("Weighted");
@@ -683,7 +691,6 @@ This file is part of LifeViewer
 		a.push(["Gnats", "R1,C2,S0-2,11,19,B11,19,NW090109010001090109"]);
 		a.push(["HexParity", "R1,C2,S0,2,4,6,B1,3,5,NW110101011H"]);
 		a.push(["Hextenders", "R1,C10,S1,3-5,B2-3,NW110101011H"]);
-		a.push(["Hex Inverse Fire", "R1,C2,S2-3,6-9,11-15,B5,10-11,14-15,NW410104041H"]);
 		a.push(["HGlass", "R1,C2,S1-3,11,21,25,29-31,B1-3,11,21,25,29-31,NW000200080110000400"]);
 		a.push(["Hogs", "R1,C2,S2-4,6,B5-6,NW023302230H"]);
 		a.push(["Jitters", "R1,C2,S4,14,B1,4,9,NW995505599"]);


### PR DESCRIPTION
- Added some aliases corresponding to 2-state ruletables still on the wiki: HexLife, cloverleafsim, MaxPeriod_2x2k2, randomnn, x-rule, water; with these added to LifeViewer, the rule tables can be removed from the wiki while maintaining pattern compatibility (the rule tables will remain accessible on the forum posts)
- Changed "X-rule-pre" to "x-rule-pre" to match ruletable capitalisation
- Corrected "Frespa" to "Farespa"
- Finally added LeapLife as an alias. No idea how one of the most popular isotropic rules slipped under the radar, but it's on the list now.
- Hex Inverse Fire is now handled with the isotropic non-totalistic hexagonal algorithm rather than the weighted life algorithm