### PR TITLE
Minor changes to Identify

### DIFF
--- a/js/life.js
+++ b/js/life.js
@@ -82,7 +82,7 @@ This file is part of LifeViewer
 		/** @const {Array<string>} */ modTypeName : ["Rot90CW", "Rot90CCW", "FlipX", "FlipY", "Rot180", "Flip" + String.fromCharCode(10189), "Flip" + String.fromCharCode(10187), "FlipOrth", "Rot90", "FlipOrthOrRot90", "FlipDiag", "FlipDiagOrRot90", "FlipXOrRot180", "FlipYOrRot180", "Flip" + String.fromCharCode(10189) + "OrRot180", "Flip" + String.fromCharCode(10187) + "OrRot180", "FlipOrthOrDiag"],
 
 		// maximum number of generations to check for oscillators
-		/** @const {number} */ maxOscillatorGens : 4194304,
+		/** @const {number} */ maxOscillatorGens : 134217728,
 
 		// maxmimum memory to compute strict volatility
 		/** @const {number} */ maxStrictMemory : 256 * 1024 * 1024,
@@ -2947,6 +2947,28 @@ This file is part of LifeViewer
 		}
 		this.cellPeriodNumCols = numCols;
 
+		// define custom colours for subperiods up to 20
+		periodCols[this.popSubPeriod.length - 2] = "rgb(028,146,205)";
+		periodCols[this.popSubPeriod.length - 3] = "rgb(010,184,123)";
+		periodCols[this.popSubPeriod.length - 4] = "rgb(232,096,117)";
+		periodCols[this.popSubPeriod.length - 5] = "rgb(248,242,144)";
+		periodCols[this.popSubPeriod.length - 6] = "rgb(186,065,023)";
+		periodCols[this.popSubPeriod.length - 7] = "rgb(217,030,155)";
+		periodCols[this.popSubPeriod.length - 8] = "rgb(190,240,233)";
+		periodCols[this.popSubPeriod.length - 9] = "rgb(066,140,040)";
+		periodCols[this.popSubPeriod.length - 10] = "rgb(111,016,068)";
+		periodCols[this.popSubPeriod.length - 11] = "rgb(118,173,244)";
+		periodCols[this.popSubPeriod.length - 12] = "rgb(045,089,099)";
+		periodCols[this.popSubPeriod.length - 13] = "rgb(217,183,144)";
+		periodCols[this.popSubPeriod.length - 14] = "rgb(128,255,128)";
+		periodCols[this.popSubPeriod.length - 15] = "rgb(144,144,255)";
+		periodCols[this.popSubPeriod.length - 16] = "rgb(192,192,000)";
+		periodCols[this.popSubPeriod.length - 17] = "rgb(128,255,255)";
+		periodCols[this.popSubPeriod.length - 18] = "rgb(255,192,255)";
+		periodCols[this.popSubPeriod.length - 19] = "rgb(255,192,192)";
+		periodCols[this.popSubPeriod.length - 20] = "rgb(255,255,000)";
+		periodCols[this.popSubPeriod.length - 21] = "rgb(255,128,000)";
+
 		// make colours for the subperiods excluding period 1 and oscillator period
 		y = 0;
 		for (x = 2; x < this.popSubPeriod.length - 1; x += 1) {
@@ -2961,7 +2983,6 @@ This file is part of LifeViewer
 		periodCols[0] = "black";
 		periodCols[1] = "rgb(168,168,168)";
 		periodCols[this.popSubPeriod.length - 1] = "rgb(255,255,255)";
-		periodCols[this.popSubPeriod.length - 2] = "rgb(028,146,205)";
 
 		// create a colour for state 6 cells
 		if (this.cellPeriodState6) {

--- a/js/life.js
+++ b/js/life.js
@@ -82,7 +82,7 @@ This file is part of LifeViewer
 		/** @const {Array<string>} */ modTypeName : ["Rot90CW", "Rot90CCW", "FlipX", "FlipY", "Rot180", "Flip" + String.fromCharCode(10189), "Flip" + String.fromCharCode(10187), "FlipOrth", "Rot90", "FlipOrthOrRot90", "FlipDiag", "FlipDiagOrRot90", "FlipXOrRot180", "FlipYOrRot180", "Flip" + String.fromCharCode(10189) + "OrRot180", "Flip" + String.fromCharCode(10187) + "OrRot180", "FlipOrthOrDiag"],
 
 		// maximum number of generations to check for oscillators
-		/** @const {number} */ maxOscillatorGens : 134217728,
+		/** @const {number} */ maxOscillatorGens : 16777216,
 
 		// maxmimum memory to compute strict volatility
 		/** @const {number} */ maxStrictMemory : 256 * 1024 * 1024,
@@ -2946,28 +2946,6 @@ This file is part of LifeViewer
 			}
 		}
 		this.cellPeriodNumCols = numCols;
-
-		// define custom colours for subperiods up to 20
-		periodCols[this.popSubPeriod.length - 2] = "rgb(028,146,205)";
-		periodCols[this.popSubPeriod.length - 3] = "rgb(010,184,123)";
-		periodCols[this.popSubPeriod.length - 4] = "rgb(232,096,117)";
-		periodCols[this.popSubPeriod.length - 5] = "rgb(248,242,144)";
-		periodCols[this.popSubPeriod.length - 6] = "rgb(186,065,023)";
-		periodCols[this.popSubPeriod.length - 7] = "rgb(217,030,155)";
-		periodCols[this.popSubPeriod.length - 8] = "rgb(190,240,233)";
-		periodCols[this.popSubPeriod.length - 9] = "rgb(066,140,040)";
-		periodCols[this.popSubPeriod.length - 10] = "rgb(111,016,068)";
-		periodCols[this.popSubPeriod.length - 11] = "rgb(118,173,244)";
-		periodCols[this.popSubPeriod.length - 12] = "rgb(045,089,099)";
-		periodCols[this.popSubPeriod.length - 13] = "rgb(217,183,144)";
-		periodCols[this.popSubPeriod.length - 14] = "rgb(128,255,128)";
-		periodCols[this.popSubPeriod.length - 15] = "rgb(144,144,255)";
-		periodCols[this.popSubPeriod.length - 16] = "rgb(192,192,000)";
-		periodCols[this.popSubPeriod.length - 17] = "rgb(128,255,255)";
-		periodCols[this.popSubPeriod.length - 18] = "rgb(255,192,255)";
-		periodCols[this.popSubPeriod.length - 19] = "rgb(255,192,192)";
-		periodCols[this.popSubPeriod.length - 20] = "rgb(255,255,000)";
-		periodCols[this.popSubPeriod.length - 21] = "rgb(255,128,000)";
 
 		// make colours for the subperiods excluding period 1 and oscillator period
 		y = 0;

--- a/js/life.js
+++ b/js/life.js
@@ -2960,7 +2960,8 @@ This file is part of LifeViewer
 		// set colours for period 1 and oscillator period
 		periodCols[0] = "black";
 		periodCols[1] = "rgb(168,168,168)";
-		periodCols[this.popSubPeriod.length - 1] = "rgb(238,238,238)";
+		periodCols[this.popSubPeriod.length - 1] = "rgb(255,255,255)";
+		periodCols[this.popSubPeriod.length - 2] = "rgb(028,146,205)";
 
 		// create a colour for state 6 cells
 		if (this.cellPeriodState6) {

--- a/js/life.js
+++ b/js/life.js
@@ -32,10 +32,10 @@ This file is part of LifeViewer
 		/** @const {number} */ modeAny : 3,
 
 		// cell period table State 6 label for [R]History and [R]Super
-		/** @const {string} */ state6Label : "St.6",
+		/** @const {string} */ state6Label : "Off DF",
 
 		// cell period table State 3 label for [R]Extended
-		/** @const {string} */ state3Label : "St.3",
+		/** @const {string} */ state3Label : "Off DF",
 
 		// number of snowflakes
 		/** @const {number} */ flakes : 50000,


### PR DESCRIPTION
- The cell state that kills all adjacent alive cells (state 6 in [R]History and [R]Super, state 3 in [R]Investigator) is now called "Off DF" in the period map key. State numbers are arbitrary, so it'd be preferable if the cell's role was explained, which it is in this case (off-deathforcer).
- Maximum period to check for in Identify is now 2^24
- Period map colour for cells that oscillate at the full period is now pure white (#FFFFFF), rather than the previously assigned pale gray (#EEEEEE)

I tried to implement some hardcoded colours for period maps based on Oscillizer's and Nakano's colour schemes, but they didn't work as expected and I'm not sure how to do this correctly. Here's the values I used in case implementing this correctly is desired:
full period: "rgb(255,255,255)";
subperiod 1: "rgb(028,146,205)";
subperiod 2: "rgb(010,184,123)";
subperiod 3: "rgb(232,096,117)";
subperiod 4: "rgb(248,242,144)";
subperiod 5: "rgb(186,065,023)";
subperiod 6: "rgb(217,030,155)";
subperiod 7: "rgb(190,240,233)";
subperiod 8: "rgb(066,140,040)";
subperiod 9: "rgb(111,016,068)";
subperiod 10: "rgb(118,173,244)";
subperiod 11: "rgb(045,089,099)";
subperiod 12: "rgb(217,183,144)";
subperiod 13: "rgb(128,255,128)";
subperiod 14: "rgb(144,144,255)";
subperiod 15: "rgb(192,192,000)";
subperiod 16: "rgb(128,255,255)";
subperiod 17: "rgb(255,192,255)";
subperiod 18: "rgb(255,192,192)";
subperiod 19: "rgb(255,255,000)";
subperiod 20: "rgb(255,128,000)";

Subperiods 21 and onwards would be generated at runtime as usual.