### PR TITLE
Use a predefined color palette for the period map

### DIFF
--- a/js/life.js
+++ b/js/life.js
@@ -3544,8 +3544,8 @@ This file is part of LifeViewer
 		}
 
 		// generate colours for the rest
-		for (let i = 0; i < subperiodColours.length - subperiodColours.length; ++i) {
-			hue = Math.floor(360 * (y / numCols));
+		for (let i = 0; i < subperiodIndices.length - subperiodColours.length; ++i) {
+			hue = Math.floor(360 * (i / numCols));
 			periodCols[subperiodIndices[i]] = "hsl(" + hue + ",100%," + (70 - (i & 3) * 12) + "%)";
 		}
 

--- a/js/life.js
+++ b/js/life.js
@@ -3508,14 +3508,45 @@ This file is part of LifeViewer
 		}
 		this.cellPeriodNumCols = numCols;
 
-		// make colours for the subperiods excluding period 1 and oscillator period
-		y = 0;
-		for (x = 2; x < this.popSubPeriod.length - 1; x += 1) {
-			if (this.popSubPeriod[x] > 0) {
-				hue = Math.floor(360 * (y / numCols));
-				periodCols[x] = "hsl(" + hue + ",100%," + (70 - (y & 3) * 12) + "%)";
-				y += 1;
+		// find existing periods excluding period 1 and oscillator period
+		const subperiodIndices = [];
+		for (let i = 2; x < this.popSubPeriod.length - 1; ++i) {
+			if (this.popSubPeriod[i] > 0) {
+				subperiodIndices.push(i);
 			}
+		}
+
+		// set predefined colours where available
+		const subperiodColours = [
+			"#1C92CD",
+			"#0AB87B",
+			"#E86075",
+			"#F8F290",
+			"#BA4117",
+			"#D91E9B",
+			"#BEF0E9",
+			"#428C28",
+			"#6F1044",
+			"#76ADF4",
+			"#2D5963",
+			"#D9B790",
+			"#80FF80",
+			"#9090FF",
+			"#C0C000",
+			"#80FFFF",
+			"#FFC0FF",
+			"#FFC0C0",
+			"#FFFF00",
+			"#FF8000",
+		];
+		for (let i = 0; i < subperiodColours.length && i < subperiodIndices.length; ++i) {
+			periodCols[subperiodIndices[subperiodIndices.length - 1 - i]] = subperiodColours[i];
+		}
+
+		// generate colours for the rest
+		for (let i = 0; i < subperiodColours.length - subperiodColours.length; ++i) {
+			hue = Math.floor(360 * (y / numCols));
+			periodCols[subperiodIndices[i]] = "hsl(" + hue + ",100%," + (70 - (i & 3) * 12) + "%)";
 		}
 
 		// set colours for period 1 and oscillator period

--- a/js/life.js
+++ b/js/life.js
@@ -3515,7 +3515,6 @@ This file is part of LifeViewer
 				subperiodIndices.push(i);
 			}
 		}
-		console.log(subperiodIndices);
 
 		// set predefined colours where available
 		const subperiodColours = [

--- a/js/life.js
+++ b/js/life.js
@@ -3510,11 +3510,12 @@ This file is part of LifeViewer
 
 		// find existing periods excluding period 1 and oscillator period
 		const subperiodIndices = [];
-		for (let i = 2; x < this.popSubPeriod.length - 1; ++i) {
+		for (let i = 2; i < this.popSubPeriod.length - 1; ++i) {
 			if (this.popSubPeriod[i] > 0) {
 				subperiodIndices.push(i);
 			}
 		}
+		console.log(subperiodIndices);
 
 		// set predefined colours where available
 		const subperiodColours = [

--- a/js/life.js
+++ b/js/life.js
@@ -3538,7 +3538,7 @@ This file is part of LifeViewer
 
 		// generate colours for the rest
 		for (let i = 0; i < subperiodIndices.length - subperiodColours.length; ++i) {
-			hue = Math.floor(360 * (i / numCols));
+			hue = Math.floor(360 * (i / (subperiodIndices.length - subperiodColours.length)));
 			periodCols[subperiodIndices[i]] = "hsl(" + hue + ",100%," + (70 - (i & 3) * 12) + "%)";
 		}
 

--- a/js/life.js
+++ b/js/life.js
@@ -3499,22 +3499,15 @@ This file is part of LifeViewer
 			cellSize = 1;
 		}
 
-		// count the subperiods excluding period 1 and oscillator period
-		numCols = 0;
-		for (x = 2; x < this.popSubPeriod.length - 1; x += 1) {
-			if (this.popSubPeriod[x] > 0) {
-				numCols += 1;
-			}
-		}
-		this.cellPeriodNumCols = numCols;
-
-		// find existing periods excluding period 1 and oscillator period
+		// find subperiods excluding period 1 and oscillator period
 		const subperiodIndices = [];
 		for (let i = 2; i < this.popSubPeriod.length - 1; ++i) {
 			if (this.popSubPeriod[i] > 0) {
 				subperiodIndices.push(i);
 			}
 		}
+		numCols = subperiodIndices.length;
+		this.cellPeriodNumCols = numCols;
 
 		// set predefined colours where available
 		const subperiodColours = [


### PR DESCRIPTION
The predefined palette is used for 20 highest subperiods, the rest is generated the same way as before.

Compare the following oscillator's period map before and after - using the current HSL system causes some adjacent regions to blend into each other, which is undesirable and what this intends to address:
x = 44, y = 1, rule = MAPAAD//zAwPz8AAP//MDA/PwAA//8AAP//AAD//wAA//8AAD8/AAD//wAAPz8AAP//wMD//wAA///AwP//AAD//w
44o!