### PR TITLE
Minor Identify changes, redone

### DIFF
--- a/js/life.js
+++ b/js/life.js
@@ -38,10 +38,10 @@ This file is part of LifeViewer
 		/** @const {number} */ modeAny : 3,
 
 		// cell period table State 6 label for [R]History and [R]Super
-		/** @const {string} */ state6Label : "St.6",
+		/** @const {string} */ state6Label : "Off DF",
 
 		// cell period table State 3 label for [R]Extended
-		/** @const {string} */ state3Label : "St.3",
+		/** @const {string} */ state3Label : "Off DF",
 
 		// number of snowflakes
 		/** @const {number} */ flakes : 50000,
@@ -3120,7 +3120,7 @@ This file is part of LifeViewer
 		// set colours for period 1 and oscillator period
 		periodCols[0] = "black";
 		periodCols[1] = "rgb(168,168,168)";
-		periodCols[this.popSubPeriod.length - 1] = "rgb(238,238,238)";
+		periodCols[this.popSubPeriod.length - 1] = "rgb(255,255,255)";
 
 		// create a colour for state 6 cells
 		if (this.cellPeriodState6) {


### PR DESCRIPTION
- Rename off-deathforcer cells to "Off DF" for [R]History, [R]Super and [R]Investigator for consistency
- Make white cells in period maps fully white

Keeping the maximum Identify period the same this time, as Pro will modify this anyway.